### PR TITLE
incorrect unit of work after flush

### DIFF
--- a/tests/Doctrine/Tests/Models/AssociationClass/AssociationClass.php
+++ b/tests/Doctrine/Tests/Models/AssociationClass/AssociationClass.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\AssociationClass;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="association_class_association")
+ */
+class AssociationClass
+{
+    /**
+     * @ORM\Id()
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue()
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Doctrine\Tests\Models\AssociationClass\ParentClass", inversedBy="associations")
+     * @ORM\JoinColumn(referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     *
+     * @var ParentClass
+     */
+    private $parent;
+
+    /**
+     * @ORM\OneToOne(targetEntity="Doctrine\Tests\Models\AssociationClass\ChildClass")
+     * @ORM\JoinColumn(referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     *
+     * @var ChildClass
+     */
+    private $child;
+
+    public function __construct(ParentClass $parent, ChildClass $child)
+    {
+        $this->parent = $parent;
+        $this->child  = $child;
+    }
+}

--- a/tests/Doctrine/Tests/Models/AssociationClass/ChildClass.php
+++ b/tests/Doctrine/Tests/Models/AssociationClass/ChildClass.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\AssociationClass;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="association_class_children")
+ */
+class ChildClass
+{
+    /**
+     * @ORM\Id()
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue()
+     *
+     * @var int
+     */
+    private $id;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Doctrine/Tests/Models/AssociationClass/ParentClass.php
+++ b/tests/Doctrine/Tests/Models/AssociationClass/ParentClass.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\AssociationClass;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="association_class_parent")
+ */
+class ParentClass
+{
+    /**
+     * @ORM\Id()
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue()
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="Doctrine\Tests\Models\AssociationClass\AssociationClass", mappedBy="parent", cascade={"persist"}, orphanRemoval=true)
+     *
+     * @var Collection<int, AssociationClass>
+     */
+    private $associations;
+
+    public function __construct()
+    {
+        $this->associations = new ArrayCollection();
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function addChild(ChildClass $child): self
+    {
+        $this->associations->add(new AssociationClass($this, $child));
+
+        return $this;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/AssociationClass/AssociationClassTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/AssociationClass/AssociationClassTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\AssociationClass;
+
+use Doctrine\Tests\Models\AssociationClass\AssociationClass;
+use Doctrine\Tests\Models\AssociationClass\ChildClass;
+use Doctrine\Tests\Models\AssociationClass\ParentClass;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function count;
+use function sprintf;
+use function var_export;
+
+class AssociationClassTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            ParentClass::class,
+            ChildClass::class,
+            AssociationClass::class
+        );
+    }
+
+    public function testUnitOfWorkWithRemoveAfterClear(): void
+    {
+        $parent      = new ParentClass();
+        $firstChild  = new ChildClass();
+        $secondChild = new ChildClass();
+
+        $parent
+            ->addChild($firstChild)
+            ->addChild($secondChild);
+
+        $this->_em->persist($firstChild);
+        $this->_em->persist($secondChild);
+        $this->_em->persist($parent);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $parent      = $this->_em->find(ParentClass::class, $parent->getId());
+        $firstChild  = $this->_em->find(ChildClass::class, $firstChild->getId());
+        $secondChild = $this->_em->find(ChildClass::class, $secondChild->getId());
+
+        $this->_em->remove($firstChild);
+        $this->_em->remove($secondChild);
+        $this->_em->remove($parent);
+
+        $this->_em->flush();
+
+        foreach ($this->_em->getUnitOfWork()->getIdentityMap() as $classString => $object) {
+            self::assertCount(0, $object, sprintf('%s contains %d objects: %s', $classString, count($object), var_export($object)));
+        }
+    }
+}


### PR DESCRIPTION
- added unit test to illustrate the problem of proxy classes being present in the unit of work after deletion of parent child construction usian an association class